### PR TITLE
fix: user subscription 생성 시 deadline 서버에서 계산

### DIFF
--- a/src/main/java/com/cupfeedeal/domain/UserSubscription/dto/request/UserSubscriptionCreateRequestDto.java
+++ b/src/main/java/com/cupfeedeal/domain/UserSubscription/dto/request/UserSubscriptionCreateRequestDto.java
@@ -4,20 +4,20 @@ import com.cupfeedeal.domain.User.entity.User;
 import com.cupfeedeal.domain.UserSubscription.entity.UserSubscription;
 import com.cupfeedeal.domain.cafeSubscriptionType.entity.CafeSubscriptionType;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static com.cupfeedeal.domain.UserSubscription.enumerate.SubscriptionStatus.VALID;
 
 public record UserSubscriptionCreateRequestDto (
         Long cafeSubscriptionTypeId,
-        LocalDateTime subscriptionStart,
-        LocalDateTime subscriptionDeadline
+        LocalDate subscriptionStart
 ){
-    public UserSubscription toEntity(User user, CafeSubscriptionType cafeSubscriptionType) {
+    public UserSubscription toEntity(User user, CafeSubscriptionType cafeSubscriptionType, LocalDateTime subscriptionDeadline) {
         return UserSubscription.builder()
                 .user(user)
                 .cafeSubscriptionType(cafeSubscriptionType)
-                .subscriptionStart(subscriptionStart)
+                .subscriptionStart(subscriptionStart.atStartOfDay())
                 .subscriptionDeadline(subscriptionDeadline)
                 .usingCount(0)
                 .subscriptionStatus(VALID)

--- a/src/main/java/com/cupfeedeal/domain/UserSubscription/sevice/UserSubscriptionService.java
+++ b/src/main/java/com/cupfeedeal/domain/UserSubscription/sevice/UserSubscriptionService.java
@@ -31,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
@@ -94,8 +95,14 @@ public class UserSubscriptionService {
         User user = customUserDetailService.loadUserByCustomUserDetails(customUserdetails);
 
         CafeSubscriptionType cafeSubscriptionType = cafeSubscriptionTypeService.findCafeSubscriptionTypeById(requestDto.cafeSubscriptionTypeId());
+
+        // subscription deadline 계산
+        LocalDateTime subscriptionDeadline = requestDto.subscriptionStart()
+                .plusDays(cafeSubscriptionType.getPeriod())
+                .atTime(23, 59, 59);
+
         // user subscription 저장
-        final UserSubscription userSubscription = requestDto.toEntity(user, cafeSubscriptionType);
+        final UserSubscription userSubscription = requestDto.toEntity(user, cafeSubscriptionType, subscriptionDeadline);
         userSubscriptionRepository.save(userSubscription);
 
         Integer newCupcatLevel;


### PR DESCRIPTION
## ✨ 연관된 이슈
> #25 


## 📝 작업 내용
구독 시작 시 startDate 만 request로 받아 deadline은 서버에서 계산하여 저장하도록 로직 수정하였습니다.

### 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
