### PR TITLE
feat: user subscription extension info 조회 서비스

### DIFF
--- a/src/main/java/com/cupfeedeal/domain/UserSubscription/dto/response/UserSubscriptionInfoResponseDto.java
+++ b/src/main/java/com/cupfeedeal/domain/UserSubscription/dto/response/UserSubscriptionInfoResponseDto.java
@@ -1,0 +1,21 @@
+package com.cupfeedeal.domain.UserSubscription.dto.response;
+
+import com.cupfeedeal.domain.UserSubscription.entity.UserSubscription;
+import com.cupfeedeal.domain.cafeSubscriptionType.entity.CafeSubscriptionType;
+
+import java.time.LocalDateTime;
+
+public record UserSubscriptionInfoResponseDto (
+        Long user_subscription_id,
+        Integer period,
+        LocalDateTime end
+){
+    public static UserSubscriptionInfoResponseDto from(UserSubscription userSubscription, CafeSubscriptionType cafeSubscriptionType) {
+        return new UserSubscriptionInfoResponseDto(
+                userSubscription.getUserSubscriptionId(),
+                cafeSubscriptionType.getPeriod() / 7,
+                userSubscription.getSubscriptionDeadline()
+        );
+    }
+}
+

--- a/src/main/java/com/cupfeedeal/domain/cafe/controller/CafeController.java
+++ b/src/main/java/com/cupfeedeal/domain/cafe/controller/CafeController.java
@@ -1,12 +1,14 @@
 package com.cupfeedeal.domain.cafe.controller;
 
 import com.cupfeedeal.domain.User.entity.CustomUserdetails;
+import com.cupfeedeal.domain.UserSubscription.sevice.UserSubscriptionService;
 import com.cupfeedeal.domain.cafe.dto.request.CafeCreateRequestDto;
 import com.cupfeedeal.domain.cafe.dto.response.CafeInfoResponseDto;
 import com.cupfeedeal.domain.cafe.dto.response.CafeListResponseDto;
 import com.cupfeedeal.domain.cafe.dto.response.CafeNewOpenListResponseDto;
 import com.cupfeedeal.domain.cafe.dto.response.CafeRecommendationListResponseDto;
 import com.cupfeedeal.domain.cafe.service.CafeService;
+import com.cupfeedeal.domain.cafeSubscriptionType.dto.request.CafeSubscriptionTypeInfoRequestDto;
 import com.cupfeedeal.domain.cafeSubscriptionType.dto.response.CafeSubscriptionInfoResponseDto;
 import com.cupfeedeal.domain.cafeSubscriptionType.service.CafeSubscriptionTypeService;
 import com.cupfeedeal.global.common.response.CommonResponse;
@@ -26,6 +28,7 @@ public class CafeController {
 
     private final CafeService cafeService;
     private final CafeSubscriptionTypeService cafeSubscriptionTypeService;
+    private final UserSubscriptionService userSubscriptionService;
 
     @Operation(summary = "cafe 생성")
     @PostMapping
@@ -67,9 +70,12 @@ public class CafeController {
     }
 
     @Operation(summary = "카페 구독권 조회")
-    @GetMapping("/{cafeId}/cafeSubscription/info")
-    public CommonResponse<CafeSubscriptionInfoResponseDto> getCafeSubscriptionInfo(@PathVariable Long cafeId) {
-        CafeSubscriptionInfoResponseDto cafeSubscriptionInfo = cafeSubscriptionTypeService.getCafeSubscriptionType(cafeId);
+    @GetMapping("/cafeSubscription/info")
+    public CommonResponse<CafeSubscriptionInfoResponseDto> getCafeSubscriptionInfo(
+            CafeSubscriptionTypeInfoRequestDto cafeSubscriptionTypeInfo,
+            @AuthenticationPrincipal CustomUserdetails customUserdetails
+    ) {
+        CafeSubscriptionInfoResponseDto cafeSubscriptionInfo = userSubscriptionService.getCafeSubscriptionType(customUserdetails, cafeSubscriptionTypeInfo);
         return new CommonResponse<>(cafeSubscriptionInfo, "해당 카페의 상세 정보 조회에 성공하였습니다.");
     }
 }

--- a/src/main/java/com/cupfeedeal/domain/cafeSubscriptionType/dto/request/CafeSubscriptionTypeInfoRequestDto.java
+++ b/src/main/java/com/cupfeedeal/domain/cafeSubscriptionType/dto/request/CafeSubscriptionTypeInfoRequestDto.java
@@ -1,0 +1,8 @@
+package com.cupfeedeal.domain.cafeSubscriptionType.dto.request;
+
+public record CafeSubscriptionTypeInfoRequestDto (
+        Long id,
+        Boolean isExtension
+){
+
+}

--- a/src/main/java/com/cupfeedeal/domain/cafeSubscriptionType/dto/response/CafeSubscriptionInfoResponseDto.java
+++ b/src/main/java/com/cupfeedeal/domain/cafeSubscriptionType/dto/response/CafeSubscriptionInfoResponseDto.java
@@ -1,5 +1,6 @@
 package com.cupfeedeal.domain.cafeSubscriptionType.dto.response;
 
+import com.cupfeedeal.domain.UserSubscription.dto.response.UserSubscriptionInfoResponseDto;
 import com.cupfeedeal.domain.cafe.entity.Cafe;
 
 import java.util.List;
@@ -9,14 +10,16 @@ public record CafeSubscriptionInfoResponseDto (
         String cafe_name,
         String menu,
         List<Integer> periods,
+        UserSubscriptionInfoResponseDto userSubscriptionInfo,
         List<CafeSubscriptionListResponseDto> cafe_subscriptions
 ){
-    public static CafeSubscriptionInfoResponseDto from(Cafe cafe, List<CafeSubscriptionListResponseDto> cafe_subscriptions) {
+    public static CafeSubscriptionInfoResponseDto from(Cafe cafe, UserSubscriptionInfoResponseDto userSubscriptionInfo, List<CafeSubscriptionListResponseDto> cafe_subscriptions) {
         return new CafeSubscriptionInfoResponseDto(
                 cafe.getId(),
                 cafe.getName(),
                 "아이스 아메리카노",
                 List.of(2, 4),
+                userSubscriptionInfo,
                 cafe_subscriptions
         );
     }

--- a/src/main/java/com/cupfeedeal/domain/cafeSubscriptionType/repository/CafeSubscriptionTypeRepository.java
+++ b/src/main/java/com/cupfeedeal/domain/cafeSubscriptionType/repository/CafeSubscriptionTypeRepository.java
@@ -1,5 +1,6 @@
 package com.cupfeedeal.domain.cafeSubscriptionType.repository;
 
+import com.cupfeedeal.domain.cafe.entity.Cafe;
 import com.cupfeedeal.domain.cafeSubscriptionType.entity.CafeSubscriptionType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,4 +10,5 @@ import java.util.List;
 @Repository
 public interface CafeSubscriptionTypeRepository extends JpaRepository<CafeSubscriptionType, Long> {
     List<CafeSubscriptionType> findAllByCafeId(Long cafeId);
+    List<CafeSubscriptionType> findAllByCafe(Cafe cafe);
 }

--- a/src/main/java/com/cupfeedeal/domain/cafeSubscriptionType/service/CafeSubscriptionTypeService.java
+++ b/src/main/java/com/cupfeedeal/domain/cafeSubscriptionType/service/CafeSubscriptionTypeService.java
@@ -1,9 +1,7 @@
 package com.cupfeedeal.domain.cafeSubscriptionType.service;
 
-import com.cupfeedeal.domain.cafe.entity.Cafe;
+import com.cupfeedeal.domain.UserSubscription.sevice.UserSubscriptionService;
 import com.cupfeedeal.domain.cafe.service.CafeService;
-import com.cupfeedeal.domain.cafeSubscriptionType.dto.response.CafeSubscriptionInfoResponseDto;
-import com.cupfeedeal.domain.cafeSubscriptionType.dto.response.CafeSubscriptionListResponseDto;
 import com.cupfeedeal.domain.cafeSubscriptionType.entity.CafeSubscriptionType;
 import com.cupfeedeal.domain.cafeSubscriptionType.repository.CafeSubscriptionTypeRepository;
 import com.cupfeedeal.global.exception.ApplicationException;
@@ -21,24 +19,11 @@ import java.util.List;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CafeSubscriptionTypeService {
-    private final CafeService cafeService;
     private final CafeSubscriptionTypeRepository cafeSubscriptionTypeRepository;
 
     public CafeSubscriptionType findCafeSubscriptionTypeById(Long cafeSubscriptionTypeId) {
         return cafeSubscriptionTypeRepository.findById(cafeSubscriptionTypeId)
                 .orElseThrow(() -> new ApplicationException(ExceptionCode.NOT_FOUND_CAFE_SUBSCRIPTION_TYPE));
-    }
-
-    public CafeSubscriptionInfoResponseDto getCafeSubscriptionType(Long cafe_id) {
-        Cafe cafe = cafeService.findCafeById(cafe_id);
-        List<CafeSubscriptionType> cafeSubscriptionTypeList = cafeSubscriptionTypeRepository.findAllByCafeId(cafe_id);
-
-        // cafeSubscriptionType list를 dto로 변환
-        List<CafeSubscriptionListResponseDto> cafeSubscriptionListResponseDtoList = cafeSubscriptionTypeList.stream()
-                .map(CafeSubscriptionListResponseDto::from)
-                .toList();
-
-        return CafeSubscriptionInfoResponseDto.from(cafe, cafeSubscriptionListResponseDtoList);
     }
 
     public List<Integer> calculateSavedCups(CafeSubscriptionType cafeSubscriptionType) {


### PR DESCRIPTION
## ✨ 연관된 이슈
> #25 


## 📝 작업 내용
구독권 연장하기 페이지에서 필요한 cafe, userSubscription, subscription 정보 조회 기능 구현하였습니다.
기존에 있던 getCafeSubscriptionType 서비스에 합치는 방식으로 수정하였습니다.

### 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
