### PR TITLE
fix: cupcat 관련 로직 수정

### DIFF
--- a/src/main/java/com/cupfeedeal/domain/Auth/service/AuthService.java
+++ b/src/main/java/com/cupfeedeal/domain/Auth/service/AuthService.java
@@ -3,6 +3,11 @@ package com.cupfeedeal.domain.Auth.service;
 import com.cupfeedeal.domain.Auth.dto.responseDto.KakaoUserInfoResponseDto;
 import com.cupfeedeal.domain.Auth.dto.responseDto.LoginResponseDto;
 import com.cupfeedeal.domain.Auth.security.JwtTokenProvider;
+import com.cupfeedeal.domain.Cupcat.entity.Cupcat;
+import com.cupfeedeal.domain.Cupcat.enumerate.CupcatTypeEnum;
+import com.cupfeedeal.domain.Cupcat.repository.CupcatRepository;
+import com.cupfeedeal.domain.Cupcat.service.CupcatTypeUtilService;
+import com.cupfeedeal.domain.Cupcat.service.UserCupcatService;
 import com.cupfeedeal.domain.User.entity.User;
 import com.cupfeedeal.domain.User.repository.UserRepository;
 import com.cupfeedeal.domain.UserSubscription.repository.UserSubscriptionRepository;
@@ -17,6 +22,9 @@ public class AuthService {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final UserSubscriptionRepository userSubscriptionRepository;
+    private final UserCupcatService userCupcatService;
+    private final CupcatRepository cupcatRepository;
+    private final CupcatTypeUtilService cupcatTypeUtilService;
 
     public LoginResponseDto login(KakaoUserInfoResponseDto userInfoResponseDto) {
         if (userRepository.findByEmail(userInfoResponseDto.getKakaoAccount().email).isPresent()) {
@@ -46,6 +54,13 @@ public class AuthService {
                     .build();
 
             userRepository.save(user);
+
+            // type random, level 0인 컵캣 생성
+            CupcatTypeEnum type = cupcatTypeUtilService.getRandomCupcatType();
+
+            Cupcat cupcat = cupcatRepository.findByLevelAndType(0, type);
+            userCupcatService.createUserCupcat(user, cupcat, null);
+
 
             String token = jwtTokenProvider.createToken(user.getUserId());
 

--- a/src/main/java/com/cupfeedeal/domain/Cupcat/repository/UserCupcatRepository.java
+++ b/src/main/java/com/cupfeedeal/domain/Cupcat/repository/UserCupcatRepository.java
@@ -4,6 +4,8 @@ import com.cupfeedeal.domain.Cupcat.entity.Cupcat;
 import com.cupfeedeal.domain.Cupcat.entity.UserCupcat;
 import com.cupfeedeal.domain.User.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,5 +18,6 @@ public interface UserCupcatRepository extends JpaRepository<UserCupcat, Long> {
 
     Optional<UserCupcat> findTop1ByUserOrderByCreatedAtDesc(User user);
 
-    List<UserCupcat> findAllByUserOrderByCreatedAtAsc(User user);
+    @Query("select uc from UserCupcat uc where uc.user = :user AND uc.cupcat.level = 5 ORDER BY uc.createdAt asc")
+    List<UserCupcat> findAllByUserOrderByCreatedAtAsc(@Param("user") User user);
 }

--- a/src/main/java/com/cupfeedeal/domain/Cupcat/repository/UserCupcatRepository.java
+++ b/src/main/java/com/cupfeedeal/domain/Cupcat/repository/UserCupcatRepository.java
@@ -14,7 +14,7 @@ public interface UserCupcatRepository extends JpaRepository<UserCupcat, Long> {
     Optional<UserCupcat> findByUser(User user);
     Optional<UserCupcat> findByCupcat(Cupcat cupcat);
 
-    Optional<UserCupcat> findTop1ByUserOrderByCreatedAtAsc(User user);
+    Optional<UserCupcat> findTop1ByUserOrderByCreatedAtDesc(User user);
 
     List<UserCupcat> findAllByUserOrderByCreatedAtAsc(User user);
 }

--- a/src/main/java/com/cupfeedeal/domain/Cupcat/service/CupcatTypeUtilService.java
+++ b/src/main/java/com/cupfeedeal/domain/Cupcat/service/CupcatTypeUtilService.java
@@ -1,0 +1,21 @@
+package com.cupfeedeal.domain.Cupcat.service;
+
+import com.cupfeedeal.domain.Cupcat.enumerate.CupcatTypeEnum;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Random;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CupcatTypeUtilService {
+    private static final Random RANDOM = new Random();
+
+    public static CupcatTypeEnum getRandomCupcatType() {
+        CupcatTypeEnum[] values = CupcatTypeEnum.values();
+        int randomIndex = RANDOM.nextInt(values.length);
+        return values[randomIndex];
+    }
+}

--- a/src/main/java/com/cupfeedeal/domain/Cupcat/service/CupcatTypeUtilService.java
+++ b/src/main/java/com/cupfeedeal/domain/Cupcat/service/CupcatTypeUtilService.java
@@ -13,7 +13,7 @@ import java.util.Random;
 public class CupcatTypeUtilService {
     private static final Random RANDOM = new Random();
 
-    public static CupcatTypeEnum getRandomCupcatType() {
+    public CupcatTypeEnum getRandomCupcatType() {
         CupcatTypeEnum[] values = CupcatTypeEnum.values();
         int randomIndex = RANDOM.nextInt(values.length);
         return values[randomIndex];

--- a/src/main/java/com/cupfeedeal/domain/Cupcat/service/UserCupcatService.java
+++ b/src/main/java/com/cupfeedeal/domain/Cupcat/service/UserCupcatService.java
@@ -15,7 +15,7 @@ public class UserCupcatService {
     private  final UserCupcatRepository userCupcatRepository;
 
     public UserCupcat findUserCupcatByUser(User user) {
-        return userCupcatRepository.findTop1ByUserOrderByCreatedAtAsc(user)
+        return userCupcatRepository.findTop1ByUserOrderByCreatedAtDesc(user)
                 .orElse(null);
     }
 

--- a/src/main/java/com/cupfeedeal/domain/User/controller/UserController.java
+++ b/src/main/java/com/cupfeedeal/domain/User/controller/UserController.java
@@ -30,9 +30,6 @@ public class UserController {
     @Operation(summary = "my page user 정보 조회")
     @GetMapping("")
     public CommonResponse<UserInfoResponseDto> getUserInfo(@AuthenticationPrincipal CustomUserdetails customUserdetails) {
-//        if (customUserdetails == null) {
-//            throw new IllegalArgumentException("인증되지 않은 사용자입니다.");
-//        }
         UserInfoResponseDto userInfoResponseDto = userService.getUserInfo(customUserdetails);
         return new CommonResponse<> (userInfoResponseDto, "회원 정보를 성공적으로 조회했습니다.");
     }

--- a/src/main/java/com/cupfeedeal/domain/User/dto/response/UserInfoResponseDto.java
+++ b/src/main/java/com/cupfeedeal/domain/User/dto/response/UserInfoResponseDto.java
@@ -1,5 +1,7 @@
 package com.cupfeedeal.domain.User.dto.response;
 
+import com.cupfeedeal.domain.Cupcat.entity.UserCupcat;
+import com.cupfeedeal.domain.User.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,11 +10,21 @@ import java.time.LocalDate;
 
 @Getter
 @Setter
-@AllArgsConstructor
-public class UserInfoResponseDto {
-    public String username;
-    public Integer user_level;
-    public String cupcatImgUrl;
-    public String cafe_name;
-    public LocalDate birth_date;
+public record UserInfoResponseDto (
+    String username,
+    Integer user_level,
+    String cupcatImgUrl,
+    String cafe_name,
+    LocalDate birth_date
+
+){
+    public static UserInfoResponseDto from(User user, UserCupcat userCupcat) {
+        return new UserInfoResponseDto(
+                user.getUsername(),
+                user.getUser_level(),
+                userCupcat == null ? null : userCupcat.getCupcat().getImageUrl(),
+                userCupcat == null ? null : userCupcat.getCafeName(),
+                userCupcat == null ? null : userCupcat.getCreatedAt().toLocalDate()
+        );
+    }
 }

--- a/src/main/java/com/cupfeedeal/domain/User/dto/response/UserInfoResponseDto.java
+++ b/src/main/java/com/cupfeedeal/domain/User/dto/response/UserInfoResponseDto.java
@@ -2,14 +2,9 @@ package com.cupfeedeal.domain.User.dto.response;
 
 import com.cupfeedeal.domain.Cupcat.entity.UserCupcat;
 import com.cupfeedeal.domain.User.entity.User;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.time.LocalDate;
 
-@Getter
-@Setter
 public record UserInfoResponseDto (
     String username,
     Integer user_level,

--- a/src/main/java/com/cupfeedeal/domain/User/service/UserService.java
+++ b/src/main/java/com/cupfeedeal/domain/User/service/UserService.java
@@ -78,6 +78,9 @@ public class UserService {
                 .toList();
     }
 
+    /*
+    지나간 컵캣 정보 조회
+     */
     public UserCupcatInfoResponseDto getCupcatInfo(CustomUserdetails customUserdetails) {
         User user = customUserDetailService.loadUserByCustomUserDetails(customUserdetails);
 

--- a/src/main/java/com/cupfeedeal/domain/User/service/UserService.java
+++ b/src/main/java/com/cupfeedeal/domain/User/service/UserService.java
@@ -1,6 +1,5 @@
 package com.cupfeedeal.domain.User.service;
 
-import com.cupfeedeal.domain.Cupcat.entity.Cupcat;
 import com.cupfeedeal.domain.Cupcat.entity.UserCupcat;
 import com.cupfeedeal.domain.Cupcat.repository.UserCupcatRepository;
 import com.cupfeedeal.domain.User.dto.response.*;
@@ -15,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,8 +28,6 @@ public class UserService {
     @Autowired
     private CustomUserDetailService customUserDetailService;
 
-
-    // 리팩토링 완전 필요
     public UserInfoResponseDto getUserInfo(CustomUserdetails customUserdetails) {
         if (customUserdetails == null || customUserdetails.getUser() == null) {
             throw new ApplicationException(ExceptionCode.USER_NOT_FOUND);
@@ -43,15 +39,7 @@ public class UserService {
         UserCupcat userCupcat = userCupcatRepository.findTop1ByUserOrderByCreatedAtAsc(user)
                 .orElse(null);
 
-
-        String cupcatImageUrl = getImgUrl(userCupcat);
-        String cafeName = userCupcat.getCafeName();
-
-        LocalDate birthDate = (userCupcat != null) ? userCupcat.getCreatedAt().toLocalDate() : null;
-
-        UserInfoResponseDto userInfoResponseDto = new UserInfoResponseDto(user.getUsername(), user.getUser_level(), cupcatImageUrl, cafeName, birthDate);
-
-        return userInfoResponseDto;
+        return UserInfoResponseDto.from(user, userCupcat);
     }
 
     public UserInfoUpdateResponseDto updateUserInfo(CustomUserdetails customUserdetails, String newUsername) {
@@ -64,13 +52,6 @@ public class UserService {
         return userInfoUpdateResponseDto;
     }
 
-    public void createUserCupcat(User user, Cupcat cupcat) {
-        UserCupcat.builder()
-                .user(user)
-                .cupcat(cupcat)
-                .build();
-    }
-
     public UserMainInfoResponseDto getUserMainInfo(CustomUserdetails customUserdetails) {
         if (customUserdetails == null || customUserdetails.getUser() == null) {
             return null;
@@ -80,12 +61,6 @@ public class UserService {
         Integer subscription_count = userSubscriptionRepository.countAllByUser(user, SubscriptionStatus.VALID);
 
         return UserMainInfoResponseDto.from(user, subscription_count, cupcatImageUrl);
-    }
-
-    public String getImgUrl(UserCupcat userCupcat) {
-        String cupcatImageUrl = userCupcat != null ? userCupcat.getCupcat().getImageUrl() : null;
-
-        return cupcatImageUrl;
     }
 
     public String getCupcatImgUrl(User user) {

--- a/src/main/java/com/cupfeedeal/domain/User/service/UserService.java
+++ b/src/main/java/com/cupfeedeal/domain/User/service/UserService.java
@@ -36,7 +36,7 @@ public class UserService {
         User user = customUserdetails.getUser();
 
         // userCupcat 조회
-        UserCupcat userCupcat = userCupcatRepository.findTop1ByUserOrderByCreatedAtAsc(user)
+        UserCupcat userCupcat = userCupcatRepository.findTop1ByUserOrderByCreatedAtDesc(user)
                 .orElse(null);
 
         return UserInfoResponseDto.from(user, userCupcat);
@@ -64,7 +64,7 @@ public class UserService {
     }
 
     public String getCupcatImgUrl(User user) {
-        Optional<UserCupcat> userCupcat = userCupcatRepository.findTop1ByUserOrderByCreatedAtAsc(user);
+        Optional<UserCupcat> userCupcat = userCupcatRepository.findTop1ByUserOrderByCreatedAtDesc(user);
         String cupcatImageUrl = userCupcat.isPresent() ? userCupcat.get().getCupcat().getImageUrl() : null;
 
         return cupcatImageUrl;


### PR DESCRIPTION
## ✨ 연관된 이슈
> #10 #36 


## 📝 작업 내용
1. user info 조회 시 예외처리
2. 회원가입 시 type random, level 0인 userCupcat 생성
3. userSubscription 생성 시 user_level + 1, userCupcat level 5인 경우 type random, level 1인 userCupcat 생성
4. 지나간 userCupcat level 5만 조회되도록 수정

### 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
