### PR TITLE
fix: cupcat level 5일 때 로직 수정

### DIFF
--- a/src/main/java/com/cupfeedeal/domain/UserSubscription/sevice/UserSubscriptionService.java
+++ b/src/main/java/com/cupfeedeal/domain/UserSubscription/sevice/UserSubscriptionService.java
@@ -140,7 +140,7 @@ public class UserSubscriptionService {
             newCupcatLevel = cupcatLevel + 1;
 
             // cupcat level이 이미 5인 경우
-            if (cupcatLevel == 6) {
+            if (cupcatLevel == 5) {
                 newCupcatLevel = 1;
                 cupcatType = cupcatTypeUtilService.getRandomCupcatType();
             }


### PR DESCRIPTION
## ✨ 연관된 이슈
> close #10 


## 📝 작업 내용
userCupcat의 level 이 이미 5인 경우 새로운 타입의 level 1 컵캣을 부여하는 로직 수정하였습니다.

### 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
