### PR TITLE
fix: extension logic

### DIFF
--- a/src/main/java/com/cupfeedeal/domain/UserSubscription/dto/request/UserSubscriptionCreateRequestDto.java
+++ b/src/main/java/com/cupfeedeal/domain/UserSubscription/dto/request/UserSubscriptionCreateRequestDto.java
@@ -18,6 +18,7 @@ public record UserSubscriptionCreateRequestDto (
                 .cafeSubscriptionType(cafeSubscriptionType)
                 .subscriptionStart(subscriptionStart.atStartOfDay())
                 .subscriptionDeadline(subscriptionDeadline)
+                .extendedSubscriptionDeadline(subscriptionDeadline)
                 .usingCount(0)
                 .subscriptionStatus(subscriptionStatus)
                 .build();

--- a/src/main/java/com/cupfeedeal/domain/UserSubscription/dto/response/UserSubscriptionListResponseDto.java
+++ b/src/main/java/com/cupfeedeal/domain/UserSubscription/dto/response/UserSubscriptionListResponseDto.java
@@ -32,7 +32,7 @@ public record UserSubscriptionListResponseDto (
                 userSubscription.getIsUsed(),
                 userSubscription.getUsingCount(),
                 userSubscription.getSubscriptionStart(),
-                userSubscription.getSubscriptionDeadline(),
+                userSubscription.getExtendedSubscriptionDeadline(),
                 remaining_days
         );
     }

--- a/src/main/java/com/cupfeedeal/domain/UserSubscription/entity/UserSubscription.java
+++ b/src/main/java/com/cupfeedeal/domain/UserSubscription/entity/UserSubscription.java
@@ -36,6 +36,9 @@ public class UserSubscription extends BaseEntity {
     @Column(name = "subscription_deadline", nullable = false)
     private LocalDateTime subscriptionDeadline;
 
+    @Column(name = "extended_subscription_deadline")
+    private LocalDateTime extendedSubscriptionDeadline;
+
     @Column(name = "isUsed", nullable = false)
     private Boolean isUsed = false;
 
@@ -51,6 +54,9 @@ public class UserSubscription extends BaseEntity {
         if (isUsed == null) {
             isUsed = false;
         }
+        if (extendedSubscriptionDeadline == null) {
+            extendedSubscriptionDeadline = subscriptionDeadline;
+        }
     }
 
     @Builder
@@ -59,6 +65,7 @@ public class UserSubscription extends BaseEntity {
         this.cafeSubscriptionType = cafeSubscriptionType;
         this.subscriptionStart = subscriptionStart;
         this.subscriptionDeadline = subscriptionDeadline;
+        this.extendedSubscriptionDeadline = subscriptionDeadline;
         this.usingCount = usingCount;
         this.subscriptionStatus = subscriptionStatus;
     }

--- a/src/main/java/com/cupfeedeal/domain/UserSubscription/repository/UserSubscriptionRepository.java
+++ b/src/main/java/com/cupfeedeal/domain/UserSubscription/repository/UserSubscriptionRepository.java
@@ -45,4 +45,7 @@ public interface UserSubscriptionRepository extends JpaRepository<UserSubscripti
 
     @Query("SELECT COUNT(us) > 0 FROM UserSubscription us WHERE us.user = :user AND us.cafeSubscriptionType = :subscription AND us.subscriptionStatus in :status")
     Boolean existsByUserAndCafeSubscriptionTypeAndStatus(@Param("user") User user, @Param("subscription") CafeSubscriptionType cafeSubscriptionType, @Param("status") List<SubscriptionStatus> status);
+
+    @Query("SELECT us FROM UserSubscription us WHERE us.user = :user AND us.cafeSubscriptionType = :subscription AND us.subscriptionStatus in :status order by us.createdAt desc LIMIT 1")
+    Optional<UserSubscription> findTop1ByUserAndCafeSubscriptionTypeAndStatus(@Param("user") User user, @Param("subscription") CafeSubscriptionType cafeSubscriptionType, @Param("status") List<SubscriptionStatus> status);
 }

--- a/src/main/java/com/cupfeedeal/domain/UserSubscription/sevice/UserSubscriptionService.java
+++ b/src/main/java/com/cupfeedeal/domain/UserSubscription/sevice/UserSubscriptionService.java
@@ -161,10 +161,6 @@ public class UserSubscriptionService {
         userCupcatService.createUserCupcat(user, newCupcat, cafeName);
     }
 
-    public void extendUserSubscription(UserSubscription userSubscription) {
-
-    }
-
     /*
     현재 구독중인 userSubscription list 조회
      */

--- a/src/main/java/com/cupfeedeal/domain/UserSubscription/sevice/UserSubscriptionService.java
+++ b/src/main/java/com/cupfeedeal/domain/UserSubscription/sevice/UserSubscriptionService.java
@@ -98,7 +98,8 @@ public class UserSubscriptionService {
 
         // 구독 가능 여부 확인
         List<SubscriptionStatus> statuses = Arrays.asList(SubscriptionStatus.VALID, SubscriptionStatus.NOTYET);
-        if (userSubscriptionRepository.countByUserAndSubscriptionStatusIsValidOrNotYet(user, statuses) == 3 && !userSubscriptionRepository.existsByUserAndCafeSubscriptionTypeAndStatus(user, cafeSubscriptionType, statuses)){
+        Optional<UserSubscription> existingUserSubscription = userSubscriptionRepository.findTop1ByUserAndCafeSubscriptionTypeAndStatus(user, cafeSubscriptionType, statuses);
+        if (userSubscriptionRepository.countByUserAndSubscriptionStatusIsValidOrNotYet(user, statuses) == 3 && existingUserSubscription.isEmpty()) {
             throw new ApplicationException(ExceptionCode.ALREADY_FULL_SUBSCRIPTION);
         }
 
@@ -120,6 +121,12 @@ public class UserSubscriptionService {
         // user subscription 저장
         final UserSubscription userSubscription = requestDto.toEntity(user, cafeSubscriptionType, subscriptionDeadline, status);
         userSubscriptionRepository.save(userSubscription);
+
+        // 구독권 연장인 경우
+        if (existingUserSubscription.isPresent()) {
+            existingUserSubscription.get().setExtendedSubscriptionDeadline(subscriptionDeadline);
+            userSubscriptionRepository.save(existingUserSubscription.get());
+        }
 
         Integer newCupcatLevel;
         CupcatTypeEnum cupcatType;
@@ -152,6 +159,10 @@ public class UserSubscriptionService {
 
         Cupcat newCupcat = cupcatRepository.findByLevelAndType(newCupcatLevel, cupcatType);
         userCupcatService.createUserCupcat(user, newCupcat, cafeName);
+    }
+
+    public void extendUserSubscription(UserSubscription userSubscription) {
+
     }
 
     /*


### PR DESCRIPTION
## ✨ 연관된 이슈
> close #10 


## 📝 작업 내용
1. userSubscription entity에 extendedSubscriptionDeadline 추가 (구독권탭 - 구독권 관리 페이지에 보여줄 용도)

2025.01.01부터 4주권 쓰다가 2주권 연장한 경우

<구독권 관리 페이지> - 기존권 구독 만료일만 업데이트
기존 4주권 구독기간
- period 4
- 구독 기간 : 2025.01.01 ~2025.02.11 (연장된 종료일까지)

이후 연장 구독권 기간
- period : 2
- 구독기간 : 2025.01.29 ~ 2025.02.11 (연장권 기간만큼만)

<마이페이지 구독 내역> - 기존권, 연장권 따로 보이도록
4주권
- 구독 기간 : 2025.01.01 ~2025.01.28

2주권
- 구독기간 : 2025.01.29 ~ 2025.02.11

### 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
